### PR TITLE
Docs: Add translation guideline

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -42,6 +42,14 @@ You may find an issue is assigned, or has the [`assigned` label](https://github.
   - Doublie version
   - Operating system **etc**
 
+### Translating Documentation
+
+#### Create a Translation
+
+- Ensure that the document is not already translated in your target language. 
+- Add the name of the language to the document as an extension, e.g: `readme.JP.md`
+- Create a Pull Request including the language in the title, e.g: `Readme: Japanese Translation`
+
 ### Submitting a pull request
 
 - Non-trivial changes are often best discussed in an issue first, to prevent you from doing unnecessary work

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,8 @@
 
 Progressive and minimal implementation of the circular and linear doublie linked list data structures in modern ES6.
 
+Visit the [contributing guidelines](https://github.com/klaussinani/doublie/blob/master/contributing.md#translating-documentation) to learn more on how to translate this document into more languages.
+
 ## Contents
 
 - [Description](#description)


### PR DESCRIPTION
## Description

The PR adds a guideline on how to translate the project's documentation.