### PR TITLE
Eliminate circular dependency between `linear` & `circular` modules

### DIFF
--- a/src/circular.js
+++ b/src/circular.js
@@ -1,5 +1,4 @@
 'use strict';
-const Linear = require('./linear');
 const List = require('./list');
 const Node = require('./node');
 
@@ -241,6 +240,7 @@ class Circular extends List {
   }
 
   toLinear() {
+    const Linear = require('./linear');
     const list = new Linear();
     this.forEach(x => list.append(x));
     return list;

--- a/src/linear.js
+++ b/src/linear.js
@@ -1,5 +1,4 @@
 'use strict';
-const Circular = require('./circular');
 const List = require('./list');
 const Node = require('./node');
 
@@ -227,6 +226,7 @@ class Linear extends List {
   }
 
   toCircular() {
+    const Circular = require('./circular');
     const list = new Circular();
     this.forEach(x => list.append(x));
     return list;


### PR DESCRIPTION
## Description

The PR eliminates the circular dependency issue between the `linear` & `circular` modules, by moving the required modules, from the global scope to the respective scope of the `Linear#toCircular()` & `Circular#toLinear()` methods.