### PR TITLE
Optimize list traversal by selecting shortest path to targeted node

### DIFF
--- a/src/circular.js
+++ b/src/circular.js
@@ -139,22 +139,6 @@ class Circular extends List {
     return list;
   }
 
-  node(index) {
-    if (!this._isValid(index)) {
-      throw new RangeError('List index out of bounds');
-    }
-
-    let count = 0;
-    let {_head: node} = this;
-
-    while (index !== count) {
-      node = node.next;
-      count++;
-    }
-
-    return node;
-  }
-
   prepend(...values) {
     values.forEach(value => {
       if (this.isEmpty()) {

--- a/src/linear.js
+++ b/src/linear.js
@@ -168,22 +168,6 @@ class Linear extends List {
     return list;
   }
 
-  node(index) {
-    if (!this._isValid(index)) {
-      throw new RangeError('List index out of bounds');
-    }
-
-    let count = 0;
-    let {_head: node} = this;
-
-    while (index !== count) {
-      node = node.next;
-      count++;
-    }
-
-    return node;
-  }
-
   prepend(...values) {
     values.forEach(value => {
       if (this.isEmpty()) {

--- a/src/list.js
+++ b/src/list.js
@@ -27,6 +27,30 @@ class List {
     return index >= 0 && index < this.length;
   }
 
+  _traverse(index) {
+    let count = 0;
+    let {_head: node} = this;
+
+    while (index !== count) {
+      node = node.next;
+      count++;
+    }
+
+    return node;
+  }
+
+  _traverseRight(index) {
+    let count = this.length - (index + 1);
+    let {_last: node} = this;
+
+    while (count !== 0) {
+      node = node.prev;
+      count--;
+    }
+
+    return node;
+  }
+
   clear() {
     this._head = null;
     this._last = null;
@@ -44,6 +68,18 @@ class List {
 
   isLinear() {
     return this.constructor.name === 'Linear';
+  }
+
+  node(index) {
+    if (!this._isValid(index)) {
+      throw new RangeError('List index out of bounds');
+    }
+
+    if (index < this.length / 2) {
+      return this._traverse(index);
+    }
+
+    return this._traverseRight(index);
   }
 }
 


### PR DESCRIPTION
## Description

The PR optimized the `List#node(index)` class method to always select the shortest path leading to the requested node. More specifically, based on the value of the given index argument, the method starts traversing the circular/linear list either from the `head` node and onwards (left-to-right), or from the `last` node and backwards (right-to-left), in order to pass through the least possible number of intermediate nodes.

## Overview

```js
  node(index) {
    // Check if given index is valid
    if (!this._isValid(index)) {
      throw new RangeError('List index out of bounds');
    }

    if (index < this.length / 2) {
      // Node is closer to `head` so start traversing the list from left-to-right 
      return this._traverse(index);
    }
    
    // Node is closer to `last` so start traversing the list form right-to-left
    return this._traverseRight(index);
  }
```