### PR TITLE
TS: make circular node's next/prev values non-null

### DIFF
--- a/test/types/circular.ts
+++ b/test/types/circular.ts
@@ -6,6 +6,10 @@ const circular = new Circular();
 circular.append('E');
 circular.head; // => Node { value: 'E', next: [Circular], prev: [Circular] }
 circular.last; // => Node { value: 'E', next: [Circular], prev: [Circular] }
+if (circular.head) {
+    circular.head.next.next;
+    // => Node { value: 'E', next: [Circular], prev: [Circular] }
+}
 circular.get(0); // => E
 
 // Return the node corresponding to the index

--- a/types/doublie.d.ts
+++ b/types/doublie.d.ts
@@ -5,8 +5,8 @@ declare namespace node {
 
   export interface Instance<T = any> {
     value: T;
-    next: Instance<T> | null;
-    prev: Instance<T> | null;
+    next: this | null;
+    prev: this | null;
   }
 }
 
@@ -61,14 +61,9 @@ declare namespace linear {
 }
 
 declare namespace circular {
-  interface LastNode<T> extends node.Instance<T> {
-    next: node.Instance<T>;
-    prev: node.Instance<T>;
-  }
-
-  interface HeadNode<T> extends node.Instance<T> {
-    next: node.Instance<T>;
-    prev: node.Instance<T>;
+  interface Node<T> extends node.Instance<T> {
+    next: this;
+    prev: this;
   }
 
   export interface Constructor {
@@ -76,10 +71,12 @@ declare namespace circular {
   }
 
   interface Instance<T = any> extends list.Instance<T> {
-    readonly head: HeadNode<T> | null;
-    readonly last: LastNode<T> | null;
+    readonly head: Node<T> | null;
+    readonly last: Node<T> | null;
     map<U>(fn: (value: T) => U): Instance<U>;
     toLinear(): linear.Instance<T>;
+    // override node()
+    node(index: number): Node<T>;
   }
 }
 


### PR DESCRIPTION
<!--

Thank you for taking the time to contribute to Signale!

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klaussinani/signale/blob/master/contributing.md).

We are always excited about pull requests!
If the pull request fixes any open issues, reference the corresponding issues in the following fashion: `Fixes #321`.
Including test results/screenshots/.gifs (if applicable/possible) alongside new features and bug fixes is something that we strongly encourage.

Thank you so much again for all of your time invested in the project!

-->
#17

This PR was created because I found this lib difficult to use in typescript with strictNullChecks on, as a line like `someNode.next.next` requires many null checks.

In both linear and circular linked lists, a node's `prev` and `next` were possibly null. This made sense for the linear case, but not for the circular case; from what I can see, if we have an existent node in a circular linked list, its `next` and `prev` values should never be null.